### PR TITLE
Fix cbw_objects with **kwargs

### DIFF
--- a/cbw_api_toolbox/cbw_objects/cbw_cve.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_cve.py
@@ -11,7 +11,8 @@ class CBWCve:
                  cve_score="",
                  last_modified="",
                  published="",
-                 updated_at=""):
+                 updated_at="",
+                 **kwargs): # pylint: disable=unused-argument
         self.content = content
         self.created_at = created_at
         self.cve_code = cve_code

--- a/cbw_api_toolbox/cbw_objects/cbw_group.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_group.py
@@ -8,7 +8,8 @@ class CBWGroup:
                  id="",  # pylint: disable=redefined-builtin
                  name="",
                  created_at="",
-                 updated_at=""):
+                 updated_at="",
+                 **kwargs): # pylint: disable=unused-argument
         self.id = id  # pylint: disable=invalid-name
         self.name = name
         self.created_at = created_at

--- a/cbw_api_toolbox/cbw_objects/cbw_node.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_node.py
@@ -12,8 +12,9 @@ class CBWNode:
                  olympe_version="",
                  cbw_on_premise_version="",
                  boot_time="",
+                 updated_at="",
                  created_at="",
-                 updated_at=""):
+                 **kwargs):  # pylint: disable=unused-argument
         self.id = id  # pylint: disable=invalid-name
         self.name = name
         self.description = description

--- a/cbw_api_toolbox/cbw_objects/cbw_package.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_package.py
@@ -9,7 +9,8 @@ class CBWPackage:
                  product="",
                  type="",  # pylint: disable=redefined-builtin
                  vendor="",
-                 version=""):
+                 version="",
+                 **kwargs): # pylint: disable=unused-argument
         self.hash_index = hash_index
         self.product = product
         self.package_type = type

--- a/cbw_api_toolbox/cbw_objects/cbw_remote_access.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_remote_access.py
@@ -16,7 +16,8 @@ class CBWRemoteAccess:
                  is_valid,
                  created_at,
                  updated_at,
-                 server):
+                 server,
+                 **kwargs): # pylint: disable=unused-argument
         self.id = id  # pylint: disable=invalid-name
         self.type = type
         self.node = CBWParser().parse(CBWNode, node) if node else None

--- a/cbw_api_toolbox/cbw_objects/cbw_server.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_server.py
@@ -28,7 +28,8 @@ class CBWServer:
                  agent_version="",
                  reboot_required=False,
                  last_communication="",
-                 state_sha2=""):
+                 state_sha2="",
+                 **kwargs): # pylint: disable=unused-argument
         self.id = id  # pylint: disable=invalid-name
         self.groups = [CBWParser().parse(CBWGroup, group) for group in groups] if groups else None
         self.hostname = hostname


### PR DESCRIPTION
There was an error when the cyberwatch api had more fields than the cyberwatch_api_tools object.