### PR TITLE
Give example of remote access creation with server_groups parameter

### DIFF
--- a/cbw_api_toolbox/cbw_api.py
+++ b/cbw_api_toolbox/cbw_api.py
@@ -129,7 +129,8 @@ class CBWApi:
                 "login": info["login"],
                 "password": info["password"],
                 "key": info["key"],
-                "node": info["node"]
+                "node": info["node"],
+                "server_groups": info["server_groups"]
             })
             logging.debug("Create connexion remote access::{}".format(response.text))
             if self.verif_response(response):

--- a/examples/create_remote_access_with_groups.py
+++ b/examples/create_remote_access_with_groups.py
@@ -1,0 +1,21 @@
+"""Create remote access"""
+
+from cbw_api_toolbox.cbw_api import CBWApi
+
+API_KEY = ''
+SECRET_KEY = ''
+API_URL = ''
+
+CLIENT = CBWApi(API_URL, API_KEY, SECRET_KEY)
+
+INFO = {"type": "", #mandatory, precises the type of the connection
+        "address": "", #mandatory, precises the IP address or the domain name of the targeted computer
+        "port": "", #mandatory, precises the port of the connection
+        "login": "", #mandatory, precises the login of the connection
+        "password": "", #precises the password of the connection
+        "key": "", #precises the key of the connection
+        "node": "", #precises the Cyberwatch source of the connection
+        "server_groups": "" #precise the group of the connection
+        }
+
+CLIENT.create_remote_access(INFO)


### PR DESCRIPTION
Update documentation and existing examples to display usage of the new server_groups parameter for ram creation.