### PR TITLE
Replacing cve_score with score

### DIFF
--- a/cbw_api_toolbox/cbw_objects/cbw_server.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_server.py
@@ -15,7 +15,9 @@ class CBWCve:
                  created_at="",
                  cve_code="",
                  level="",
-                 cve_score="",
+                 score="",
+                 score_v2="",
+                 score_v3="",
                  last_modified="",
                  published="",
                  updated_at="",
@@ -25,7 +27,9 @@ class CBWCve:
         self.content = content
         self.created_at = created_at
         self.cve_code = cve_code
-        self.cve_score = cve_score
+        self.score = score
+        self.score_v2 = score_v2
+        self.score_v3 = score_v3
         self.level = level
         self.last_modified = last_modified
         self.published = published

--- a/documentation.md
+++ b/documentation.md
@@ -265,7 +265,9 @@ Send a GET request to `/api/v2/groups` to get informations about all groups
 | created_at                | String (date) | Creation date of the CVE in Cyberwatch| "2019-04-08T22:17:34.000+02:00"               |
 | cve_code                  | String        | CVE code                          | "CVE-2019-5953"                                   |
 | level                     | String        | CVSS Score level                  | "level_medium"                                    |
-| cve_score                 | Float         | CVE score                         | 4.4                                               |
+| score                     | Float         | CVE score (CVSS v2 or v3, depends on options) | 4.4                                   |
+| score_v2                  | Float         | CVE score from CVSS v2            | 4.4                                               |
+| score_v3                  | Float         | CVE score from CVSS v3            | 4.4                                               |
 | last_modified             | String        | Last modification date of the CVE by the authorities| "2019-04-26T16:45:22.000+02:00" |
 | published                 | String        | Publication date of the CVE by the authorities| "2019-04-09T23:29:03.000+02:00"       |
 | updated_at                | String (date) | Last modification date of the CVE in Cyberwatch| "2019-04-29T09:33:37.000+02:00"      |


### PR DESCRIPTION
Issue #81 

Using the new attribute `score` instead of `cve_score` for CVSS v3 score compatibility