### PR TITLE
Added description attribute to group model

### DIFF
--- a/cbw_api_toolbox/cbw_objects/cbw_group.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_group.py
@@ -7,10 +7,12 @@ class CBWGroup:
     def __init__(self,
                  id="",  # pylint: disable=redefined-builtin
                  name="",
+                 description="",
                  created_at="",
                  updated_at="",
                  **kwargs): # pylint: disable=unused-argument
         self.id = id  # pylint: disable=invalid-name
         self.name = name
+        self.description = description
         self.created_at = created_at
         self.updated_at = updated_at

--- a/documentation.md
+++ b/documentation.md
@@ -184,6 +184,7 @@ Send a GET request to `/api/v2/groups` to get informations about all groups
 | id                        | Int           | id of the group                   | 140                                               |
 | created_at                | String (date) | Date of creation                  | "2018-07-23T09:41:31.000+02:00"                   |
 | name                      | String        | name of the group                 | "app_windows"                                     |
+| description               | String        | Description of the group          | "main servers"                                    |
 | updated_at                | String (date) | Date of last update               | "2018-07-23T09:41:31.000+02:00"                   |
 
 ### Deploying period


### PR DESCRIPTION
The PowerShell API has a `description` attribute  for the object `groups` that was missing in the Python API group model

- Added `description`  attribute to `group` model