### PR TITLE
Make params optional for cve_announcements

### DIFF
--- a/cbw_api_toolbox/cbw_api.py
+++ b/cbw_api_toolbox/cbw_api.py
@@ -6,6 +6,7 @@ import sys
 
 from urllib.parse import urlparse
 from urllib.parse import parse_qs
+from collections import defaultdict
 import requests
 from requests.exceptions import ProxyError, SSLError, RetryError, InvalidHeader, MissingSchema
 from urllib3.exceptions import NewConnectionError, MaxRetryError
@@ -208,7 +209,7 @@ class CBWApi:
 
         return CBWParser().parse_response(CBWCve, response)
 
-    def cve_announcements(self, params):
+    def cve_announcements(self, params=defaultdict()):
         """GET request to /api/v3/cve_announcements to get a list of cve_announcement"""
 
         if 'page' in params:


### PR DESCRIPTION

The method cve_announcements() requires a mandatory parameter that should actually be optional