### PR TITLE
GET on specifi servers now returns a list of server_cve dictionnaries and no longer cve objects

### DIFF
--- a/cbw_api_toolbox/cbw_objects/cbw_server.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_server.py
@@ -85,8 +85,7 @@ class CBWServer:
                                   compliance_groups] if compliance_groups else []
         self.created_at = created_at
         self.environment = environment
-        self.cve_announcements = [CBWParser().parse(CBWCve, cve) for cve in
-                                  cve_announcements] if cve_announcements else []
+        self.cve_announcements = cve_announcements
         self.cve_announcements_count = cve_announcements_count
         self.deploying_period = (CBWParser().parse(CBWDeployingPeriod, deploying_period) if
                                  deploying_period else None)


### PR DESCRIPTION
A list of CVE objects was not suitable for the cve_announcements attribute for the server model. The API indeed returns server_cve attributes. 

The cve_code was the only common attribute. With this change we now can access the fixed_at, comment, and ignored property of a server_cve when we query the api for a server.

 This change is breaking and will impact existing scripts.
