### PR TITLE
added "fixed_at" and "ignored" fields to CBWCve class

### DIFF
--- a/cbw_api_toolbox/cbw_objects/cbw_server.py
+++ b/cbw_api_toolbox/cbw_objects/cbw_server.py
@@ -43,6 +43,8 @@ class CBWCve:
         self.published = published
         self.updated_at = updated_at
         self.exploit_code_maturity = exploit_code_maturity
+        self.fixed_at = kwargs.get("fixed_at", "")
+        self.ignored = kwargs.get("ignored", "")
         self.servers = [{"server": CBWParser().parse(CBWServer, server),
                          "active": server["active"], "ignored": server["ignored"],
                          "comment": server["comment"], "fixed_at": server["fixed_at"]}


### PR DESCRIPTION
The API gives these fields when fetching a server with `/api/v3/servers/`.

Using kwargs here because I was getting a tuple if I add them as new arguments to the class.