### PR TITLE
updating library version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='cbw-api-toolbox',
     description='CyberWatch Api Tools.',
     long_description=open('README.md').read().strip(),
-    version='1.1.1',
+    version='1.1.2',
     author='CyberWatch SAS',
     author_email='support-it+api@cyberwatch.fr',
     license='MIT',


### PR DESCRIPTION
Version 1.1.2 : in cbw_server.py, self.cve_announcements is assigned directly to the object affected at initialization instead of a parsed object.

Signed-off-by: Nicolas <nicolas@cyberwatch.fr>