### PR TITLE
Fixing the re-raising bug

### DIFF
--- a/examples/create_remote_by_host.py
+++ b/examples/create_remote_by_host.py
@@ -104,9 +104,9 @@ def launch_script(parsed_args):
         try:
             for subnet in parsed_args.subnet:
                 ipaddress.ip_network(subnet, strict=False)
-        except ValueError:
-            print("Please provide valid subnet")
-            raise
+        except ValueError as v_error:
+            raise ValueError("Please provide valid subnet") from v_error
+
     client = connect_api()
     if parsed_args.subnet == []:
         add_hosts_all_subnets(client, parsed_args)


### PR DESCRIPTION
When raising a new exception (rather than using a bare raise to re-raise the exception currently being handled), the implicit exception context can be supplemented with an explicit cause by using from with raise:

    raise new_exc from original_exc

The expression following from must be an exception or None. It will be set as __cause__ on the raised exception. Setting __cause__ also implicitly sets the __suppress_context__ attribute to True, so that using raise new_exc from None effectively replaces the old exception with the new one for display purposes (e.g. converting KeyError to AttributeError), while leaving the old exception available in __context__ for introspection when debugging.

[See documentation for more](https://docs.python.org/3/library/exceptions.html)

Signed-off-by: Nicolas <nicolas@cyberwatch.fr>