### PR TITLE
Add `show vulnerabilities` subcommand for docker-images

### DIFF
--- a/bin/cyberwatch-cli
+++ b/bin/cyberwatch-cli
@@ -22,14 +22,16 @@ docker_image_subparser = docker_image_parser.add_subparsers(dest="action", help=
 docker_image_subparser.required = True
 
 def docker_image_cli(args, api):
-    if args.action == "update":
-        docker_image_update_cli(args, api)
-    elif args.action == "create":
+    if args.action == "create":
         docker_image_create_cli(args, api)
-    elif args.action == "scan":
-        docker_image_scan_cli(args, api)
     elif args.action == "list":
         docker_image_list_cli(args, api)
+    elif args.action == "scan":
+        docker_image_scan_cli(args, api)
+    elif args.action == "show":
+        docker_image_show_cli(args, api)
+    elif args.action == "update":
+        docker_image_update_cli(args, api)
     else:
         print(f"'{args.action}' is not a valid subcommand of docker-image")
 
@@ -92,6 +94,37 @@ docker_image_update.add_argument("docker_image_id")
 def docker_image_update_cli(args, api):
     params = docker_image_update_params_from_args(params={}, args=args)
     api.update_docker_image(args.docker_image_id, params=params)
+
+# Show
+docker_image_show = docker_image_subparser.add_parser('show', help="Show informations about a docker image")
+docker_image_show_subparser = docker_image_show.add_subparsers(dest="information", help="Information to show")
+docker_image_show_subparser.required = True
+
+def docker_image_show_cli(args, api):
+    if args.information == "vulnerabilities":
+        docker_image_show_vulnerabilities(args, api)
+    else:
+        print(f"'{args.object}'")
+
+# Show vulnerabilities
+docker_image_show_vulnerabilities_parser = docker_image_show_subparser.add_parser("vulnerabilities", help="Show vulnerabilities about a scanned docker image")
+docker_image_show_vulnerabilities_parser.add_argument("docker_image_id")
+
+def docker_image_show_vulnerabilities(args, api):
+    docker_image = api.docker_image(args.docker_image_id)
+    server_id = str(docker_image[6])
+    server = api.server(server_id)
+
+    vulnerabilities = server.cve_announcements
+    CVE_ANNOUNCEMENT_FORMAT_STRING = "{cve_code:14} {score:<5} {technologies}"
+    print(CVE_ANNOUNCEMENT_FORMAT_STRING.format(cve_code="CVE", score="SCORE", technologies="TECHNOLOGIES"))
+    for vulnerability in vulnerabilities:
+        cve_code = vulnerability.cve_code
+        cve_announcement = api.cve_announcement(cve_code)
+        print(CVE_ANNOUNCEMENT_FORMAT_STRING.format(cve_code=cve_announcement.cve_code, score=cve_announcement.score, technologies=",".join(f"{techno.vendor}:{techno.product}" for techno in cve_announcement.technologies)))
+
+    if vulnerabilities:
+        raise Exception("Some vulnerabilities have been found")
 
 # Scan
 docker_image_scan = docker_image_subparser.add_parser('scan', help="Scan a docker image")

--- a/bin/cyberwatch-cli
+++ b/bin/cyberwatch-cli
@@ -28,6 +28,8 @@ def docker_image_cli(args, api):
         docker_image_create_cli(args, api)
     elif args.action == "scan":
         docker_image_scan_cli(args, api)
+    elif args.action == "list":
+        docker_image_list_cli(args, api)
     else:
         print(f"'{args.action}' is not a valid subcommand of docker-image")
 
@@ -49,6 +51,34 @@ def docker_image_create_cli(args, api):
     params = docker_image_update_params_from_args(params, args)
     result = api.create_docker_image(params=params)
     print(result.id)
+
+# List
+docker_image_list = docker_image_subparser.add_parser('list', help="List docker images present on instance")
+
+def docker_image_list_cli(args, api):
+    images = api.docker_images()
+    DOCKER_IMAGE_FORMAT_STRING = "{id:<3} {image:30.30} {node_id:<4} {server_id:<6} {docker_engine_id:<6} {docker_registry_id:<8}"
+    print(
+        DOCKER_IMAGE_FORMAT_STRING.format(
+            id="ID",
+            image="IMAGE:TAG",
+            node_id="NODE",
+            server_id="SERVER",
+            docker_engine_id="ENGINE",
+            docker_registry_id="REGISTRY",
+        )
+    )
+    for image in images:
+        print(
+            DOCKER_IMAGE_FORMAT_STRING.format(
+                id=image.id,
+                image=f"{image.image_name}:{image.image_tag}",
+                node_id=image.node_id,
+                server_id=image.server_id,
+                docker_engine_id=image.docker_engine_id,
+                docker_registry_id=image.docker_registry_id,
+            )
+        )
 
 # Update
 docker_image_update = docker_image_subparser.add_parser('update', help="Update a docker image")

--- a/bin/cyberwatch-cli
+++ b/bin/cyberwatch-cli
@@ -28,6 +28,8 @@ def docker_image_cli(args, api):
         docker_image_create_cli(args, api)
     elif args.action == "scan":
         docker_image_scan_cli(args, api)
+    else:
+        print(f"'{args.action}' is not a valid subcommand of docker-image")
 
 # Create
 docker_image_create = docker_image_subparser.add_parser('create',  help="Create a docker image")
@@ -115,6 +117,8 @@ if __name__ == '__main__':
     try:
         if args.resource == "docker-image":
             docker_image_cli(args, api)
+        else:
+            print("'{args.resource}' is not a valid resource.")
     except Exception as exception:
         print(exception)
         sys.exit(1)

--- a/bin/cyberwatch-cli
+++ b/bin/cyberwatch-cli
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
 import sys
-import time
 import argparse
-from dateutil import parser as datetime_parser
-from datetime import datetime, timedelta
 
 from cbw_api_toolbox.cbw_api import CBWApi
+
+from cli import docker_image
 
 parser = argparse.ArgumentParser(description="Cli to interact with Cyberwatch API.")
 parser.add_argument("--api-url", type=str, help="Url of the Cyberwatch API")
@@ -15,162 +14,7 @@ parser.add_argument("--secret-key", type=str, help="Secret Key of the Cyberwatch
 subparser = parser.add_subparsers(dest="resource", help="Resources to interact with")
 subparser.required = True
 
-# -- Docker image --
-
-docker_image_parser = subparser.add_parser('docker-image', help="Interact with docker images")
-docker_image_subparser = docker_image_parser.add_subparsers(dest="action", help="Actions on docker images")
-docker_image_subparser.required = True
-
-def docker_image_cli(args, api):
-    if args.action == "create":
-        docker_image_create_cli(args, api)
-    elif args.action == "list":
-        docker_image_list_cli(args, api)
-    elif args.action == "scan":
-        docker_image_scan_cli(args, api)
-    elif args.action == "show":
-        docker_image_show_cli(args, api)
-    elif args.action == "update":
-        docker_image_update_cli(args, api)
-    else:
-        print(f"'{args.action}' is not a valid subcommand of docker-image")
-
-# Create
-docker_image_create = docker_image_subparser.add_parser('create',  help="Create a docker image")
-docker_image_create.add_argument('--from-image', type=int, help="The image id from with the new docker image will be created")
-docker_image_create.add_argument('--name', type=str, help="Set the image name of the docker image")
-docker_image_create.add_argument('--tag', type=str, help="Set the image tag of the docker image")
-docker_image_create.add_argument('--registry-id', type=str, help="Set the registry id of the docker image")
-docker_image_create.add_argument('--engine-id', type=str, help="Set the engine id of the docker image")
-docker_image_create.add_argument('--node-id', type=str, help="Set the node of the docker image")
-
-def docker_image_create_cli(args, api):
-    params = {}
-    if args.from_image:
-        from_image = api.docker_image(str(args.from_image))
-        for key, value in zip(["docker_image_id", "image_name", "image_tag", "docker_registry_id", "docker_engine_id", "node_id", "server_id"], from_image):
-            params[key] = value
-    params = docker_image_update_params_from_args(params, args)
-    result = api.create_docker_image(params=params)
-    print(result.id)
-
-# List
-docker_image_list = docker_image_subparser.add_parser('list', help="List docker images present on instance")
-
-def docker_image_list_cli(args, api):
-    images = api.docker_images()
-    DOCKER_IMAGE_FORMAT_STRING = "{id:<3} {image:30.30} {node_id:<4} {server_id:<6} {docker_engine_id:<6} {docker_registry_id:<8}"
-    print(
-        DOCKER_IMAGE_FORMAT_STRING.format(
-            id="ID",
-            image="IMAGE:TAG",
-            node_id="NODE",
-            server_id="SERVER",
-            docker_engine_id="ENGINE",
-            docker_registry_id="REGISTRY",
-        )
-    )
-    for image in images:
-        print(
-            DOCKER_IMAGE_FORMAT_STRING.format(
-                id=image.id,
-                image=f"{image.image_name}:{image.image_tag}",
-                node_id=image.node_id,
-                server_id=image.server_id,
-                docker_engine_id=image.docker_engine_id,
-                docker_registry_id=image.docker_registry_id,
-            )
-        )
-
-# Update
-docker_image_update = docker_image_subparser.add_parser('update', help="Update a docker image")
-docker_image_update.add_argument('--name', type=str, help="Edit the image name of the docker image")
-docker_image_update.add_argument('--tag', type=str, help="Edit the image tag of the docker image")
-docker_image_update.add_argument('--registry-id', type=str, help="Edit the registry id of the docker image")
-docker_image_update.add_argument('--engine-id', type=str, help="Edit the engine id of the docker image")
-docker_image_update.add_argument('--node-id', type=str, help="Edit the node of the docker image")
-docker_image_update.add_argument("docker_image_id")
-
-def docker_image_update_cli(args, api):
-    params = docker_image_update_params_from_args(params={}, args=args)
-    api.update_docker_image(args.docker_image_id, params=params)
-
-# Show
-docker_image_show = docker_image_subparser.add_parser('show', help="Show informations about a docker image")
-docker_image_show_subparser = docker_image_show.add_subparsers(dest="information", help="Information to show")
-docker_image_show_subparser.required = True
-
-def docker_image_show_cli(args, api):
-    if args.information == "vulnerabilities":
-        docker_image_show_vulnerabilities(args, api)
-    else:
-        print(f"'{args.object}'")
-
-# Show vulnerabilities
-docker_image_show_vulnerabilities_parser = docker_image_show_subparser.add_parser("vulnerabilities", help="Show vulnerabilities about a scanned docker image")
-docker_image_show_vulnerabilities_parser.add_argument("docker_image_id")
-
-def docker_image_show_vulnerabilities(args, api):
-    docker_image = api.docker_image(args.docker_image_id)
-    server_id = str(docker_image[6])
-    server = api.server(server_id)
-
-    vulnerabilities = server.cve_announcements
-    CVE_ANNOUNCEMENT_FORMAT_STRING = "{cve_code:14} {score:<5} {technologies}"
-    print(CVE_ANNOUNCEMENT_FORMAT_STRING.format(cve_code="CVE", score="SCORE", technologies="TECHNOLOGIES"))
-    for vulnerability in vulnerabilities:
-        cve_code = vulnerability.cve_code
-        cve_announcement = api.cve_announcement(cve_code)
-        print(CVE_ANNOUNCEMENT_FORMAT_STRING.format(cve_code=cve_announcement.cve_code, score=cve_announcement.score, technologies=",".join(f"{techno.vendor}:{techno.product}" for techno in cve_announcement.technologies)))
-
-    if vulnerabilities:
-        raise Exception("Some vulnerabilities have been found")
-
-# Scan
-docker_image_scan = docker_image_subparser.add_parser('scan', help="Scan a docker image")
-docker_image_scan.add_argument("--wait", action="store_true", help="Wait for the scan to finish before returning")
-docker_image_scan.add_argument("--timeout", type=int, default=300, help="Duration in second to wait for the scan to finish before failing")
-docker_image_scan.add_argument("docker_image_id")
-
-def docker_image_scan_cli(args, api):
-    server = api.docker_image(args.docker_image_id)
-    server_id = str(server[6])
-    api.server_refresh(server_id)
-
-    if args.wait:
-        start_time = datetime.now()
-        while not is_timeout(start_time, timeout=args.timeout):
-            if analysis_is_finished(server_id, api, start_time):
-                return
-            time.sleep(2)
-        raise TimeoutError("Timeout while waiting for the scan to finish")
-
-def is_timeout(last_time, timeout):
-    time = datetime.now()
-    timeout_delta = timedelta(seconds=timeout)
-    return (time - last_time) > timeout_delta
-
-def get_last_server_analysis(server_id, api):
-    server = api.server(server_id)
-    return datetime_parser.parse(server.analyzed_at)
-
-def analysis_is_finished(server_id, api, start_time):
-    last_analysis = get_last_server_analysis(server_id, api)
-    last_analysis = last_analysis.replace(tzinfo=None)
-    return last_analysis > start_time
-
-def docker_image_update_params_from_args(params, args):
-    if args.name:
-        params["image_name"] = args.name
-    if args.tag:
-        params["image_tag"] = args.tag
-    if args.registry_id:
-        params["docker_registry_id"] = args.registry_id
-    if args.engine_id:
-        params["docker_engine_id"] = args.engine_id
-    if args.node_id:
-        params["docker_node_id"] = args.node_id
-    return params
+docker_image.configure_parser(subparser)
 
 # -- main --
 
@@ -179,7 +23,7 @@ if __name__ == '__main__':
     api = CBWApi(args.api_url, args.api_key, args.secret_key)
     try:
         if args.resource == "docker-image":
-            docker_image_cli(args, api)
+            docker_image.subcommand(args, api)
         else:
             print("'{args.resource}' is not a valid resource.")
     except Exception as exception:

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/cli/docker_image/__init__.py
+++ b/cli/docker_image/__init__.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import sys
+from . import create, list, update, show, scan
+
+
+def configure_parser(subparser):
+    docker_image_parser = subparser.add_parser(
+        "docker-image", help="Interact with docker images"
+    )
+    docker_image_subparser = docker_image_parser.add_subparsers(
+        dest="action", help="Actions on docker images"
+    )
+    docker_image_subparser.required = True
+
+    create.configure_parser(docker_image_subparser)
+    list.configure_parser(docker_image_subparser)
+    update.configure_parser(docker_image_subparser)
+    show.configure_parser(docker_image_subparser)
+    scan.configure_parser(docker_image_subparser)
+
+
+def subcommand(args, api):
+    if args.action == "create":
+        create.subcommand(args, api)
+    elif args.action == "list":
+        list.subcommand(args, api)
+    elif args.action == "scan":
+        scan.subcommand(args, api)
+    elif args.action == "show":
+        show.subcommand(args, api)
+    elif args.action == "update":
+        update.subcommand(args, api)
+    else:
+        print(
+            f"'{args.action}' is not a valid subcommand of docker-image",
+            file=sys.stderr,
+        )
+        exit(1)

--- a/cli/docker_image/create.py
+++ b/cli/docker_image/create.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+
+def configure_parser(docker_image_subparser):
+    docker_image_create = docker_image_subparser.add_parser(
+        "create", help="Create a docker image"
+    )
+    docker_image_create.add_argument(
+        "--from-image",
+        type=int,
+        help="The image id from with the new docker image will be created",
+    )
+    docker_image_create.add_argument(
+        "--name", type=str, help="Set the image name of the docker image"
+    )
+    docker_image_create.add_argument(
+        "--tag", type=str, help="Set the image tag of the docker image"
+    )
+    docker_image_create.add_argument(
+        "--registry-id",
+        type=str,
+        help="Set the registry id of the docker image",
+    )
+    docker_image_create.add_argument(
+        "--engine-id", type=str, help="Set the engine id of the docker image"
+    )
+    docker_image_create.add_argument(
+        "--node-id", type=str, help="Set the node of the docker image"
+    )
+
+
+IMAGE_FIELDS = [
+    "docker_image_id",
+    "image_name",
+    "image_tag",
+    "docker_registry_id",
+    "docker_engine_id",
+    "node_id",
+    "server_id",
+]
+
+
+def subcommand(args, api):
+    params = {}
+    if args.from_image:
+        from_image = api.docker_image(str(args.from_image))
+        for key, value in zip(IMAGE_FIELDS, from_image):
+            params[key] = value
+    params = docker_image_update_params_from_args(params, args)
+    result = api.create_docker_image(params=params)
+    print(result.id)
+
+
+def docker_image_update_params_from_args(params, args):
+    if args.name:
+        params["image_name"] = args.name
+    if args.tag:
+        params["image_tag"] = args.tag
+    if args.registry_id:
+        params["docker_registry_id"] = args.registry_id
+    if args.engine_id:
+        params["docker_engine_id"] = args.engine_id
+    if args.node_id:
+        params["docker_node_id"] = args.node_id
+    return params

--- a/cli/docker_image/list.py
+++ b/cli/docker_image/list.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+
+def configure_parser(docker_image_subparser):
+    docker_image_subparser.add_parser(
+        "list", help="List docker images present on instance"
+    )
+
+
+def subcommand(args, api):
+    images = api.docker_images()
+    DOCKER_IMAGE_FORMAT_STRING = (
+        "{id:<3} "
+        "{image:30.30} "
+        "{node_id:<4} "
+        "{server_id:<6} "
+        "{docker_engine_id:<6} "
+        "{docker_registry_id:<8}"
+    )
+    print(
+        DOCKER_IMAGE_FORMAT_STRING.format(
+            id="ID",
+            image="IMAGE:TAG",
+            node_id="NODE",
+            server_id="SERVER",
+            docker_engine_id="ENGINE",
+            docker_registry_id="REGISTRY",
+        )
+    )
+    for image in images:
+        print(
+            DOCKER_IMAGE_FORMAT_STRING.format(
+                id=image.id,
+                image=f"{image.image_name}:{image.image_tag}",
+                node_id=image.node_id,
+                server_id=image.server_id,
+                docker_engine_id=image.docker_engine_id,
+                docker_registry_id=image.docker_registry_id,
+            )
+        )

--- a/cli/docker_image/scan.py
+++ b/cli/docker_image/scan.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import time
+from dateutil import parser as datetime_parser
+from datetime import datetime, timedelta
+
+
+def configure_parser(docker_image_subparser):
+    docker_image_scan = docker_image_subparser.add_parser(
+        "scan", help="Scan a docker image"
+    )
+    docker_image_scan.add_argument(
+        "--wait",
+        action="store_true",
+        help="Wait for the scan to finish before returning",
+    )
+    docker_image_scan.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help=(
+            "Duration in second to wait for the scan "
+            "to finish before failing"
+        ),
+    )
+    docker_image_scan.add_argument("docker_image_id")
+
+
+def subcommand(args, api):
+    server = api.docker_image(args.docker_image_id)
+    server_id = str(server[6])
+    api.server_refresh(server_id)
+
+    if args.wait:
+        start_time = datetime.now()
+        while not is_timeout(start_time, timeout=args.timeout):
+            if analysis_is_finished(server_id, api, start_time):
+                return
+            time.sleep(2)
+        raise TimeoutError("Timeout while waiting for the scan to finish")
+
+
+def is_timeout(last_time, timeout):
+    time = datetime.now()
+    timeout_delta = timedelta(seconds=timeout)
+    return (time - last_time) > timeout_delta
+
+
+def get_last_server_analysis(server_id, api):
+    server = api.server(server_id)
+    return datetime_parser.parse(server.analyzed_at)
+
+
+def analysis_is_finished(server_id, api, start_time):
+    last_analysis = get_last_server_analysis(server_id, api)
+    last_analysis = last_analysis.replace(tzinfo=None)
+    return last_analysis > start_time

--- a/cli/docker_image/show.py
+++ b/cli/docker_image/show.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+import xml.etree.ElementTree as ET
 
 
 def configure_parser(docker_image_subparser):
@@ -37,6 +38,11 @@ def init_show_vulnerabilities_subcommand(docker_image_show_subparser):
         )
     )
     docker_image_show_vulnerabilities_parser.add_argument("docker_image_id")
+    docker_image_show_vulnerabilities_parser.add_argument(
+        "--format",
+        default="text",
+        help="Format supported are 'junit-xml' and 'text'.",
+    )
 
 
 def vulnerabilities_subcommand(args, api):
@@ -53,16 +59,38 @@ def vulnerabilities_subcommand(args, api):
     server_id = str(docker_image[6])
     server = api.server(server_id)
 
+    cve_announcements = []
     vulnerabilities = server.cve_announcements
+    for vulnerability in vulnerabilities:
+        cve_code = vulnerability.cve_code
+        cve_announcements.append(api.cve_announcement(cve_code))
+    generate_output(cve_announcements, docker_image, args, api)
+
+    if vulnerabilities:
+        exit(1)
+
+
+def generate_output(cve_announcements, docker_image, args, api):
+    if args.format == "text":
+        generate_text_output(cve_announcements)
+    elif args.format == "junit-xml":
+        generate_junit_xml_output(cve_announcements, docker_image, api)
+    else:
+        print(
+            f"The following format is not supported: '{args.format}'.",
+            file=sys.stderr,
+        )
+        exit(1)
+
+
+def generate_text_output(cve_announcements):
     CVE_ANNOUNCEMENT_FORMAT_STRING = "{cve_code:14} {score:<5} {technologies}"
     print(
         CVE_ANNOUNCEMENT_FORMAT_STRING.format(
             cve_code="CVE", score="SCORE", technologies="TECHNOLOGIES"
         )
     )
-    for vulnerability in vulnerabilities:
-        cve_code = vulnerability.cve_code
-        cve_announcement = api.cve_announcement(cve_code)
+    for cve_announcement in cve_announcements:
         print(
             CVE_ANNOUNCEMENT_FORMAT_STRING.format(
                 cve_code=cve_announcement.cve_code,
@@ -74,6 +102,39 @@ def vulnerabilities_subcommand(args, api):
             )
         )
 
-    if vulnerabilities:
-        print("Some vulnerabilities have been found")
-        exit(1)
+
+def generate_junit_xml_output(cve_announcements, docker_image, api):
+    testsuite = ET.Element(
+        "testsuite", name="Vulnerabilities for docker image"
+    )
+    for cve_announcement in cve_announcements:
+        technos = ",".join(
+            f"{techno.vendor}:{techno.product}"
+            for techno in cve_announcement.technologies
+        )
+        testcase = ET.SubElement(
+            testsuite,
+            "testcase",
+            classname=f"{docker_image[1]}:{docker_image[2]}",
+            name=(
+                f"Vulnerability {cve_announcement.cve_code} "
+                f"has been detected on technologies {technos} "
+                f"with a score of {cve_announcement.score}"
+            ),
+            file=cve_announcement.cve_code,
+            time="0.0",
+        )
+        failure = ET.SubElement(
+            testcase, "failure", message=f"A vulnerability has been found."
+        )
+        failure.text = prettify_cve_announcement(cve_announcement, api.api_url)
+    print(ET.tostring(testsuite).decode())
+
+
+def prettify_cve_announcement(cve_announcement, api_url):
+    return (
+        f"[{cve_announcement.cve_code}] {cve_announcement.content}\n"
+        f"Score: {cve_announcement.score}\n"
+        f"Exploit code maturity: {cve_announcement.exploit_code_maturity}\n"
+        f"Link: {api_url}/cve_announcements/{cve_announcement.cve_code}\n"
+    )

--- a/cli/docker_image/show.py
+++ b/cli/docker_image/show.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import sys
+
+
+def configure_parser(docker_image_subparser):
+    docker_image_show = docker_image_subparser.add_parser(
+        "show", help="Show informations about a docker image"
+    )
+    docker_image_show_subparser = docker_image_show.add_subparsers(
+        dest="information", help="Information to show"
+    )
+    docker_image_show_subparser.required = True
+
+    init_show_vulnerabilities_subcommand(docker_image_show_subparser)
+
+
+def subcommand(args, api):
+    if args.information == "vulnerabilities":
+        vulnerabilities_subcommand(args, api)
+    else:
+        print(
+            f"'{args.information}' is not a valid information to show.",
+            file=sys.stderr,
+        )
+        exit(1)
+
+
+# Vulnerabilities
+
+
+def init_show_vulnerabilities_subcommand(docker_image_show_subparser):
+    docker_image_show_vulnerabilities_parser = (
+        docker_image_show_subparser.add_parser(
+            "vulnerabilities",
+            help="Show vulnerabilities about a scanned docker image",
+        )
+    )
+    docker_image_show_vulnerabilities_parser.add_argument("docker_image_id")
+
+
+def vulnerabilities_subcommand(args, api):
+    docker_image = api.docker_image(args.docker_image_id)
+    if docker_image is None:
+        print(
+            (
+                f"No docker image with id={args.docker_image_id} "
+                "has been found on Cyberwatch's instance."
+            ),
+            file=sys.stderr,
+        )
+        exit(1)
+    server_id = str(docker_image[6])
+    server = api.server(server_id)
+
+    vulnerabilities = server.cve_announcements
+    CVE_ANNOUNCEMENT_FORMAT_STRING = "{cve_code:14} {score:<5} {technologies}"
+    print(
+        CVE_ANNOUNCEMENT_FORMAT_STRING.format(
+            cve_code="CVE", score="SCORE", technologies="TECHNOLOGIES"
+        )
+    )
+    for vulnerability in vulnerabilities:
+        cve_code = vulnerability.cve_code
+        cve_announcement = api.cve_announcement(cve_code)
+        print(
+            CVE_ANNOUNCEMENT_FORMAT_STRING.format(
+                cve_code=cve_announcement.cve_code,
+                score=cve_announcement.score,
+                technologies=",".join(
+                    f"{techno.vendor}:{techno.product}"
+                    for techno in cve_announcement.technologies
+                ),
+            )
+        )
+
+    if vulnerabilities:
+        print("Some vulnerabilities have been found")
+        exit(1)

--- a/cli/docker_image/update.py
+++ b/cli/docker_image/update.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+
+def configure_parser(docker_image_subparser):
+    docker_image_update = docker_image_subparser.add_parser(
+        "update", help="Update a docker image"
+    )
+    docker_image_update.add_argument(
+        "--name", type=str, help="Edit the image name of the docker image"
+    )
+    docker_image_update.add_argument(
+        "--tag", type=str, help="Edit the image tag of the docker image"
+    )
+    docker_image_update.add_argument(
+        "--registry-id",
+        type=str,
+        help="Edit the registry id of the docker image",
+    )
+    docker_image_update.add_argument(
+        "--engine-id", type=str, help="Edit the engine id of the docker image"
+    )
+    docker_image_update.add_argument(
+        "--node-id", type=str, help="Edit the node of the docker image"
+    )
+    docker_image_update.add_argument("docker_image_id")
+
+
+def subcommand(args, api):
+    params = docker_image_update_params_from_args(params={}, args=args)
+    api.update_docker_image(args.docker_image_id, params=params)
+
+
+def docker_image_update_params_from_args(params, args):
+    if args.name:
+        params["image_name"] = args.name
+    if args.tag:
+        params["image_tag"] = args.tag
+    if args.registry_id:
+        params["docker_registry_id"] = args.registry_id
+    if args.engine_id:
+        params["docker_engine_id"] = args.engine_id
+    if args.node_id:
+        params["docker_node_id"] = args.node_id
+    return params

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='cbw-api-toolbox',
@@ -15,7 +15,7 @@ setup(
     },
     py_modules=['cbw-api-toolbox'],
     zip_safe=False,
-    packages=['cbw_api_toolbox'],
+    packages=find_packages(),
     package_dir={'cbw_api_toolbox': 'cbw_api_toolbox'},
     install_requires=[
         "requests>=2.20.1",


### PR DESCRIPTION
This MR adds the `show vulnerabilities` subcommand for docker-images proposed in issue #233. This is still a work-in-progress.

# Subcommands added

The following commands are added:

##  List

The list command truncates image name to 30 characters.

```sh
$ cyberwatch-cli docker-image list
ID  IMAGE:TAG                      NODE SERVER ENGINE REGISTRY
1   library/a_very_too_long_name_w 1    431    2      1       
2   library/ubuntu:latest          1    432    2      1       
3   library/ubuntu:18.04           1    433    2      1       
4   library/node:12                1    434    2      1       
```

## Show vulnerabilities

```sh
$ export DOCKER_IMAGE_ID=3
$ cyberwatch-cli docker-image show vulnerabilities $DOCKER_IMAGE_ID
CVE            SCORE TECHNOLOGIES
CVE-2020-3810  5.5   debian:apt,debian:debian_linux
CVE-2020-27350 5.7   debian:advanced_package_tool
CVE-2020-24659 7.5   gnu:gnutls,fedoraproject:fedora
CVE-2020-13777 7.4   gnu:gnutls,canonical:ubuntu_linux,debian:debian_linux,fedoraproject:fedora
CVE-2020-29362 5.3   p11-kit_project:p11-kit
CVE-2020-29363 7.5   p11-kit_project:p11-kit,debian:debian_linux
CVE-2020-29361 7.5   p11-kit_project:p11-kit
CVE-2018-20482 4.7   gnu:tar,debian:debian_linux,opensuse:leap
CVE-2019-9923  7.5   opensuse:leap,gnu:tar
```

The default return value when retrieving a server using `api.server(server_id)` contain only a list of `cve_code`. To retrieve more information, `api.cve_announcement(cve_code)` is used.

In this version, the command line exits with the return code 1 if at least one vulnerability is found on the image. But in pipelines, maybe some users will want that the command fails only if high values cve are found.

# WIP

Here are the steps that needs to be done:
- [x] Add `--output` and `--format` to `show vulnerabilities` subcommands.
- [x] Refactor `cyberwatch-cli` to use multiple files