### PR TITLE
Fix gitleaks by matching exactly api credentials

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,7 +1,11 @@
 title = "gitleaks config"
 [[rules]]
-	description = "API credentials"
-	regex = '''(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)'''
+	description = "API key id"
+	regex = '''(?:[A-Za-z0-9+\/]{4}){10}[A-Za-z0-9+\/]{3}='''
+	tags = ["cbw", "API"]
+[[rules]]
+	description = "API secret key"
+	regex = '''(?:[A-Za-z0-9+\/]{4}){21}[A-Za-z0-9+\/]{2}=='''
 	tags = ["cbw", "API"]
 [[rules]]
 	description = "AWS Manager ID"
@@ -112,5 +116,5 @@ title = "gitleaks config"
 	]
 	paths = [
 		'''examples/''',
-		'''spec/test_cbw_api.py'''
+		'''spec/'''
 	]


### PR DESCRIPTION
The pipeline https://github.com/Cyberwatch/cyberwatch_api_toolbox/runs/2120731255 failed because all `=` in commits were matched by the base64 regexp. This PR modifies the regexp to match exactly API keys.