### PR TITLE
Add a Dockerfile to run the cli

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!README.md
+!cli
+!bin
+!setup.py
+!cbw_api_toolbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-slim
+
+ENV INSTALL_PATH=/api
+
+WORKDIR $INSTALL_PATH
+
+COPY . .
+
+RUN python setup.py install
+
+ENTRYPOINT ["/usr/local/bin/cyberwatch-cli"]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,19 @@ scanning docker images.
 The command line is installed as part of the [the classic installation
 process](../README.md#Installation).
 
+## Use the Dockerfile
+
+To use the api inside a docker container, you can use the Dockerfile. First,
+build the image (here tagged as `cbw-api`), then you can run it with
+environnement variables.
+
+```sh
+docker build . -t cbw-api
+docker run --rm -e CBW_API_URL=https://myinstance.local \
+                -e CBW_API_KEY="PyXpxrcJ7rQ..." \
+                -e CBW_SECRET_KEY="+bUx37WnB0qt..." cbw-api
+```
+
 ## The syntax of `cyberwatch-cli`
 
 The `cyberwatch-cli` command uses the following syntax:


### PR DESCRIPTION
This PR adds a `Dockerfile` that can be used to run the `cyberwatch-cli` program easily inside a docker container.