### PR TITLE
Add `download` and `upload` subcommands to `airgap_script`

### DIFF
--- a/bin/cyberwatch-cli
+++ b/bin/cyberwatch-cli
@@ -5,7 +5,7 @@ import argparse
 
 from cbw_api_toolbox.cbw_api import CBWApi
 
-from cli import docker_image
+from cli import docker_image, airgap
 
 parser = argparse.ArgumentParser(description="Cli to interact with Cyberwatch API.")
 parser.add_argument("--api-url", type=str, help="Url of the Cyberwatch API")
@@ -15,15 +15,18 @@ subparser = parser.add_subparsers(dest="resource", help="Resources to interact w
 subparser.required = True
 
 docker_image.configure_parser(subparser)
+airgap.configure_parser(subparser)
 
 # -- main --
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parser.parse_args()
     api = CBWApi(args.api_url, args.api_key, args.secret_key)
     try:
         if args.resource == "docker-image":
             docker_image.subcommand(args, api)
+        if args.resource == "airgap":
+            airgap.subcommand(args, api)
         else:
             print("'{args.resource}' is not a valid resource.")
     except Exception as exception:

--- a/cbw_api_toolbox/cbw_api.py
+++ b/cbw_api_toolbox/cbw_api.py
@@ -66,11 +66,12 @@ class CBWApi: # pylint: disable=R0904
         """Parse the response text of an API request"""
         try:
             result = json.loads(response.text, object_hook=lambda d: namedtuple('cbw_object', d.keys())(*d.values()))
+            return result
         except TypeError:
             self.logger.error("An error occurred while parsing response")
-        return result
+            sys.exit(-1)
 
-    def _request(self, verb, payloads, body_params=None):
+    def _request(self, verb, payloads, body_params=None, params=None):
         route = self._build_route(payloads)
 
         if body_params is not None:
@@ -81,6 +82,7 @@ class CBWApi: # pylint: disable=R0904
                 verb,
                 route,
                 data=body_params,
+                params=params,
                 auth=CBWAuth(self.api_key, self.secret_key),
                 verify=self.verify_ssl)
 
@@ -93,7 +95,6 @@ class CBWApi: # pylint: disable=R0904
             self.logger.error("An error occurred, please check your API_URL.")
             sys.exit(-1)
 
-        return None
     def _get_pages(self, verb, route, params):
         """ Get one or more pages for a method using api v3 pagination """
         response_list = []
@@ -518,9 +519,9 @@ class CBWApi: # pylint: disable=R0904
 
         return self._cbw_parser(response)
 
-    def fetch_airgapped_script(self, script_id):
+    def fetch_airgapped_script(self, script_id, params=None):
         """GET request to /api/v2/cbw_scans/scripts/{SCRIPT_ID} to get a specific air gapped scanning script"""
-        response = self._request("GET", [ROUTE_AIRGAPPED_SCRIPTS, script_id])
+        response = self._request("GET", [ROUTE_AIRGAPPED_SCRIPTS, script_id], params=params)
         if response.status_code != 200:
             logging.error("Error for script with id {} :: {}".format(script_id, response.text))
             return None

--- a/cli/airgap/__init__.py
+++ b/cli/airgap/__init__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+"""This module contains all the commands related to airgaps assets."""
+
+import sys
+from . import download_scripts, upload
+
+
+def configure_parser(subparser):
+    """Adds the `airgap` subcommand to an argparse ArgumentParser
+    object"""
+    airgap_parser = subparser.add_parser("airgap", help="Interact with airgap")
+    airgap_subparser = airgap_parser.add_subparsers(
+        dest="action", help="Actions on airgap"
+    )
+    airgap_subparser.required = True
+
+    download_scripts.configure_parser(airgap_subparser)
+    upload.configure_parser(airgap_subparser)
+
+
+def subcommand(args, api):
+    """Execute the right airgap subcommand from args."""
+    if args.action == "download-scripts":
+        download_scripts.subcommand(args, api)
+    elif args.action == "upload":
+        upload.subcommand(args, api)
+    else:
+        print(
+            f"'{args.action}' is not a valid subcommand for airgap",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/cli/airgap/download_scripts.py
+++ b/cli/airgap/download_scripts.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+"""This module contain a "download-scripts" subcommand for the airgap
+resource."""
+
+import os
+from itertools import groupby
+from os.path import abspath, basename, dirname, join
+
+import requests
+
+from cbw_api_toolbox.cbw_api import CBWApi
+
+SH_EXECUTE_SCRIPT = """#!/bin/bash
+set -eu
+
+readonly DIR="$( cd "$( dirname "${{BASH_SOURCE[0]}}" )" &> /dev/null && pwd )"
+
+for script in {}; do
+    script=$DIR/$script
+    chmod +x "$script"
+    >&2 printf "Executing %s..." "$script"
+    ( "$script" || >&2 echo "Error" ; ) && >&2 echo "Done"
+done
+"""
+
+
+def configure_parser(airgap_subparser):
+    """Adds the parser for the "download-scripts" command to an argparse
+    ArgumentParser"""
+    airgap_download_scripts = airgap_subparser.add_parser(
+        "download-scripts", help="Download some airgap scripts"
+    )
+    airgap_download_scripts.add_argument(
+        "--no-attachment", default=False, action="store_true"
+    )
+    airgap_download_scripts.add_argument("--dest-dir", default="cyberwatch-airgap")
+
+
+def subcommand(args, api: CBWApi):
+    """Execute the "download" command with args."""
+
+    script_dir = join(abspath(args.dest_dir), "scripts")
+    os.makedirs(script_dir, exist_ok=True)
+
+    upload_dir = join(abspath(args.dest_dir), "uploads")
+    os.makedirs(upload_dir, exist_ok=True)
+
+    airgap_scripts_list = api.fetch_airgapped_scripts()
+    script_os_association = groupby(
+        sorted(
+            download_individual_script(
+                script_object,
+                script_dir,
+                api,
+                with_attachment=not args.no_attachment,
+            )
+            for script_object in airgap_scripts_list
+        ),
+        lambda x: x[0],
+    )
+
+    create_run_scripts(script_os_association, base_directory=script_dir)
+    print("INFO: Script saved in {}".format(script_dir))
+
+
+def download_individual_script(
+    script_object, base_directory, api: CBWApi, with_attachment=False
+):
+    """Get each script and put it in the correct category"""
+    script = api.fetch_airgapped_script(str(script_object.id), params={"pristine": "1"})
+    if script is None or script.type is None:
+        return None, None
+
+    target_os, script_name = script.type.split("::")[1:]
+    script_filename = join(base_directory, "/".join((target_os, script_name)))
+    os.makedirs(dirname(script_filename), exist_ok=True)
+    script_filename = append_extension(script_filename)
+
+    with open(script_filename, "w") as filestream:
+        filestream.write(script.contents)
+
+    if script.attachment and with_attachment:
+        download_attachment(directory=dirname(script_filename), url=script.attachment)
+
+    return target_os, basename(script_filename)
+
+
+def download_attachment(directory, url):
+    """Download attachment"""
+    attachment = requests.get(url, allow_redirects=True, verify=False)
+    attachment_filename = join(directory, basename(url))
+    with open(attachment_filename, "wb") as file:
+        file.write(attachment.content)
+
+
+def append_extension(script_filename):
+    """Append ".sh" or ".ps1" extension according to the OS"""
+    os_target = script_filename.split("/")[-2]
+    if os_target in ("Aix", "Linux", "Macos", "Vmware"):
+        return f"{script_filename}.sh"
+    if os_target == "Windows":
+        return f"{script_filename}.ps1"
+    return script_filename
+
+
+def create_run_scripts(script_os_association, base_directory):
+    """Create the run script according to the operating system in
+    subdirectories"""
+    for os_target, scripts in script_os_association:
+        target_dir = join(base_directory, os_target)
+        if os_target in ("Aix", "Linux", "Macos", "Vmware"):
+            add_sh_run_script(scripts, target_dir)
+        if os_target == "Windows":
+            add_pwsh_run_script(scripts, target_dir)
+
+
+def add_sh_run_script(os_and_scripts, directory):
+    """Create a shell run script in directory"""
+    run_script = join(directory, "run")
+    with open(run_script, "w") as file_stream:
+        file_stream.write(
+            SH_EXECUTE_SCRIPT.format(" ".join(script for (_, script) in os_and_scripts))
+        )
+        os.chmod(run_script, 0o755)
+
+
+def add_pwsh_run_script(os_and_scripts, directory):
+    """Creates a "windows launch all" powershell script"""
+    run_script_filename = join(directory, "run.ps1")
+    with open(run_script_filename, "w") as file_stream:
+        file_stream.write("$ScriptDir = Split-Path $MyInvocation.MyCommand.Path\n")
+        for _, script in os_and_scripts:
+            file_stream.write(f'& "$ScriptDir/{script}"\n')

--- a/cli/airgap/upload.py
+++ b/cli/airgap/upload.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+"""This module contain a "upload" subcommand for the airgap resource."""
+
+import os
+import sys
+import chardet
+
+from cbw_api_toolbox.cbw_api import CBWApi
+
+
+def configure_parser(airgap_script_subparser):
+    """Adds the parser for the "upload" command to an argparse ArgumentParser"""
+    airgap_script_upload = airgap_script_subparser.add_parser(
+        "upload", help="Upload some airgap result of scripts"
+    )
+    airgap_script_upload.add_argument("files", nargs="*", help="Files to upload")
+
+
+def subcommand(args, api: CBWApi):
+    """Execute the "upload" command with args."""
+    files = args.files
+    if not args.files:
+        if not "cyberwatch-airgap" in os.listdir("."):
+            print(
+                "You need to provide a list of files to upload. "
+                "The default is to upload all files present in "
+                "a folder named 'cyberwatch-airgap/uploads' in your current directory."
+            )
+            sys.exit(1)
+
+        files = (
+            os.path.join(os.getcwd(), "cyberwatch-airgap", "uploads", name)
+            for name in os.listdir("cyberwatch-airgap/uploads")
+        )
+    for script_result in files:
+        upload_file(script_result, api)
+
+
+def upload_file(result_script_filename, api: CBWApi):
+    """Upload the `result_script_filename` to the Cyberwatch instance"""
+    file_content = read_file_all_encodings(result_script_filename)
+    json_content = {"output": file_content}
+    print(f"INFO: Sending {result_script_filename} content to the API...")
+    api.upload_airgapped_results(json_content)
+
+
+def read_file_all_encodings(filename):
+    """Return the content of `filename`. Detects the encoding used by the
+    file."""
+    with open(filename, "rb") as file_stream:
+        raw_content = file_stream.read()
+    detection = chardet.detect(raw_content)
+    return raw_content.decode(detection["encoding"])

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,3 +126,88 @@ cyberwatch-cli docker-image show vulnerabilities --format junit-xml
 
 Notice that a docker image must have been scanned before vulnerabilities can be
 listed.
+
+## Manage airgap assets
+
+The command line interface can be used to download the scripts from the
+Cyberwatch instance, and upload the results of these scripts.
+
+### Download the scripts
+
+To download the scripts to the default directory `scripts`:
+
+```sh
+cyberwatch-cli airgap download-scripts
+```
+
+By default, this command creates a tree structure similar to this one:
+
+```
+cyberwatch-airgap
+├── scripts
+│   ├── Aix
+│   │   ├── InfoScript.sh
+│   │   └── run
+│   ├── Linux
+│   │   ├── InfoScript.sh
+│   │   ├── MetadataScript.sh
+│   │   ├── PortsScript.sh
+│   │   └── run
+│   ├── Macos
+│   │   ├── InfoScript.sh
+│   │   └── run
+│   ├── Vmware
+│   │   ├── InfoScript.sh
+│   │   └── run
+│   └── Windows
+│       ├── cbw_launch_all.ps1
+│       ├── InfoScript.ps1
+│       ├── MetadataScript.ps1
+│       ├── PackagesScript.ps1
+│       ├── PortsScript.ps1
+│       └── WuaScript.ps1
+└── uploads
+```
+
+The scripts downloaded from the Cyberwatch instance are stored in the `scripts` subfolder.
+
+To specify a different destination directory:
+
+```sh
+export CYBERWATCH_DIR=/tmp/cyberwatch-airgap
+cyberwatch-cli airgap download-scripts --dest-dir $CYBERWATCH_DIR
+```
+
+### Execute the scripts
+
+To execute the scripts on a linux machine:
+
+```sh
+./cyberwatch-airgap/scripts/Linux/run > "cyberwatch-airgap/uploads/$(hostname)"
+```
+
+You can also copy the `cyberwatch-airgap/scripts/Linux` directory to an other
+machine and execute the script on it.
+
+To execute the scripts on a windows machine:
+
+```powershell
+.\cyberwatch-airgap\scripts\Windows\run.ps1 > .\cyberwatch-airgap\uploads\${env:COMPUTERNAME}
+```
+
+### Upload the results
+
+To upload the results of the scripts:
+
+```sh
+cyberwatch-cli airgap upload
+```
+
+If no file are provided, the script tries to upload all the files present in
+`cyberwatch-airgap/uploads` (relative to the current directory).
+
+To provide manually the list of files to upload:
+
+```sh
+cyberwatch-cli airgap upload /tmp/cyberwatch-airgap/uploads/*
+```


### PR DESCRIPTION
This PR adds the `airgap_script` resource to the command line interface. It adds `download` and `upload` subcommand.

The workflow is:

1. Download the scripts (the default destination is `Scripts`).

```sh
cyberwatch-cli airgap download-scripts --dest-dir /tmp/scripts
# Or this (default destination is `scripts`)
cyberwatch-cli airgap download-scripts
```

2. Run the scripts.

```sh
mkdir assets
/tmp/script/Linux/run > "assets/$(hostname)"
```

3. Upload the results.

```sh
cyberwatch-cli airgap upload assets/*
```

Closes #228 