### PR TITLE
Exit with code 1 when resource is wrong

### DIFF
--- a/bin/cyberwatch-cli
+++ b/bin/cyberwatch-cli
@@ -25,7 +25,8 @@ if __name__ == '__main__':
         if args.resource == "docker-image":
             docker_image.subcommand(args, api)
         else:
-            print("'{args.resource}' is not a valid resource.")
+            print(f"'{args.resource}' is not a valid resource.", file=sys.stderr)
+            sys.exit(1)
     except Exception as exception:
         print(exception)
         sys.exit(1)


### PR DESCRIPTION
It is important to exit with a code different from 0 so that CI/CD pipelines
detect that something is wrong and fail.

There was also missing an `f` to enable the f-string.