### PR TITLE
Fix wrong if-if-else logic

### DIFF
--- a/bin/cyberwatch-cli
+++ b/bin/cyberwatch-cli
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     try:
         if args.resource == "docker-image":
             docker_image.subcommand(args, api)
-        if args.resource == "airgap":
+        elif args.resource == "airgap":
             airgap.subcommand(args, api)
         else:
             print(f"'{args.resource}' is not a valid resource.", file=sys.stderr)


### PR DESCRIPTION
When the resource was `docker-image`, the else statement was executed. This is
not the indented behaviour.