### PR TITLE
Add Chardet module to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 openpyxl
 xlsxwriter
 python-dateutil
+chardet

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
         "requests>=2.20.1",
         "XlsxWriter>=1.2.1",
         "openpyxl>=3.0.6",
-        "python-dateutil>=2.8.1"
+        "python-dateutil>=2.8.1",
+        "chardet>=3.0.4"
     ],
     scripts=['bin/cyberwatch-cli']
 )


### PR DESCRIPTION
This fixes an error with the docker container that reported a missing `chardet` module.