### PR TITLE
Update the 'release' workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
The 'release' workflow was running on ubuntu-18.04 which wasn't supported anymore since 03/04/2023 ([https://github.com/actions/runner-images/issues/6002](https://github.com/actions/runner-images/issues/6002)).
Now it is always using the 'ubuntu-latest' image, as stated in the documentation : [https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)
